### PR TITLE
Support `use: actions/github-script` to enable setting multiple outputs

### DIFF
--- a/.github/package-lock.json
+++ b/.github/package-lock.json
@@ -1,12 +1,12 @@
 {
-    "name": "ts-scripts",
-    "version": "0.0.1",
+    "name": "@urcomputeringpal/github-script-ts-private-scripts",
+    "version": "0.0.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
-            "name": "ts-scripts",
-            "version": "0.0.1",
+            "name": "@urcomputeringpal/github-script-ts-private-scripts",
+            "version": "0.0.2",
             "dependencies": {
                 "@urcomputeringpal/github-script-ts": "0.0.5"
             },

--- a/.github/package.json
+++ b/.github/package.json
@@ -1,7 +1,12 @@
 {
-    "name": "ts-scripts",
-    "version": "0.0.1",
+    "name": "@urcomputeringpal/github-script-ts-private-scripts",
+    "version": "0.0.2",
     "private": true,
+    "files": [
+        "dist/**/*.d.ts",
+        "dist/**/*.js"
+    ],
+    "main": "dist/index.js",
     "scripts": {
         "format": "prettier --write .",
         "format:check": "prettier --check .",

--- a/.github/src/index.ts
+++ b/.github/src/index.ts
@@ -1,4 +1,4 @@
 // export all functions we want to call from Actions
 export { prNumber } from "./prNumber";
 export { getLabel } from "./getLabel";
-export { setEnv } from "./setEnv";
+export { setOutput } from "./setOutput";

--- a/.github/src/index.ts
+++ b/.github/src/index.ts
@@ -1,2 +1,4 @@
+// export all functions we want to call from Actions
 export { prNumber } from "./prNumber";
 export { getLabel } from "./getLabel";
+export { setEnv } from "./setEnv";

--- a/.github/src/setEnv.ts
+++ b/.github/src/setEnv.ts
@@ -1,0 +1,12 @@
+import { GitHubScriptArguments } from "@urcomputeringpal/github-script-ts";
+
+export async function setEnv(args: GitHubScriptArguments): Promise<String> {
+    const { core } = args;
+    if (core === undefined) {
+        throw new Error("core is undefined");
+    }
+    const name = process.env["VARIABLE_NAME"] ?? "NAME";
+    const value = process.env["VARIABLE_VALUE"] ?? "";
+    core.exportVariable(name, value);
+    return "";
+}

--- a/.github/src/setOutput.ts
+++ b/.github/src/setOutput.ts
@@ -1,12 +1,13 @@
 import { GitHubScriptArguments } from "@urcomputeringpal/github-script-ts";
 
-export async function setEnv(args: GitHubScriptArguments): Promise<String> {
+export async function setOutput(args: GitHubScriptArguments): Promise<String> {
     const { core } = args;
     if (core === undefined) {
         throw new Error("core is undefined");
     }
-    const name = process.env["VARIABLE_NAME"] ?? "NAME";
-    const value = process.env["VARIABLE_VALUE"] ?? "";
+    const name = process.env["OUTPUT_NAME"] ?? "NAME";
+    const value = process.env["OUTPUT_VALUE"] ?? "";
     core.exportVariable(name, value);
+    core.setOutput(name, value);
     return "";
 }

--- a/.github/tsconfig.json
+++ b/.github/tsconfig.json
@@ -3,7 +3,9 @@
         "module": "commonjs",
         "declaration": true,
         "target": "es5",
-        "strict": true
+        "strict": true,
+        "outDir": "dist",
+        "esModuleInterop": true
     },
     "include": ["src/*.ts"],
     "exclude": ["node_modules", "**/*.test.ts"]

--- a/.github/workflows/npm.yaml
+++ b/.github/workflows/npm.yaml
@@ -15,3 +15,14 @@ jobs:
               with:
                   access: public
                   token: ${{ secrets.NPM_TOKEN }}
+
+    renovate:
+        name: Update
+        needs: publish
+        uses: urcomputeringpal/.github/.github/workflows/renovate.yaml@main
+        with:
+            renovate_app_slug: ur-renovate
+            onboarding: "true"
+        secrets:
+            RENOVATE_APP_ID: ${{ secrets.RENOVATE_APP_ID }}
+            RENOVATE_APP_PEM: ${{ secrets.RENOVATE_APP_PEM }}

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -1,9 +1,5 @@
 name: renovate
 on:
-    push:
-        branches:
-            - main
-            - renovate/configure
     pull_request:
     workflow_dispatch: {}
     schedule:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,7 +15,7 @@ jobs:
               name: Setup
               id: github-script-ts
               with:
-                  build: npm run format && npm run test && npm run build && npm install
+                  build: npm run format && npm run test && npm run build
                   path: ./.github
 
             - name: Run prNumber

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,9 +13,9 @@ jobs:
 
             - uses: ./
               name: Setup
-              id: setup
+              id: github-script-ts
               with:
-                  build: npm run format && npm run test && npm run build
+                  build: npm run format && npm run test && npm run build && npm install
                   path: ./.github
 
             - name: Run prNumber
@@ -47,3 +47,18 @@ jobs:
             - if: github.event.act != 'true' && github.event_name == 'pull_request'
               run: |
                   [ "${{ steps.getLabel.outputs.result }}" == "test" ]
+
+            - name: Run setEnv function using actions/github-script
+              uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
+              env:
+                  VARIABLE_NAME: "SET_ENV"
+                  VARIABLE_VALUE: "worked"
+              with:
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
+                  result-encoding: string
+                  script: |
+                      const { setEnv } = await import("${{ steps.github-script-ts.outputs.module }}");
+                      const result = await setEnv({core});
+
+            - run: |
+                  [ "${SET_ENV}" == "worked" ]

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -45,10 +45,11 @@ jobs:
               run: |
                   [ "${{ steps.getLabel.outputs.result }}" == "test" ]
 
-            - name: setOutput and exportVariable suprisingly work when called in a composite run step
+            - name: exportVariable suprisingly works when called in a composite run step in act
               id: exportVariable
+              if: github.event.act == 'true'
               env:
-                  OUTPUT_NAME: "SET_IN_COMPOSITE_WORKFLOW"
+                  OUTPUT_NAME: "SHOULD_NOT_WORK"
                   OUTPUT_VALUE: "cool"
               uses: ./
               with:
@@ -57,9 +58,22 @@ jobs:
 
             - run: |
                   set -x
-                  [ "${{ steps.exportVariable.outputs.SET_IN_COMPOSITE_WORKFLOW }}" == "cool" ]
-                  [ "${SET_IN_COMPOSITE_WORKFLOW}" == "cool" ]
-                  [ "${{ env.SET_IN_COMPOSITE_WORKFLOW }}" == "cool" ]
+                  [ "${{ steps.exportVariable.outputs.SHOULD_NOT_WORK }}" == "cool" ]
+
+            - name: exportVariable does not bubble up from composite run steps on actions runners
+              id: exportVariableActions
+              if: github.event.act != 'true'
+              env:
+                  OUTPUT_NAME: "SHOULD_NOT_WORK"
+                  OUTPUT_VALUE: "cool"
+              uses: ./
+              with:
+                  function: setOutput
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
+
+            - run: |
+                  set -x
+                  [ "${{ steps.exportVariableActions.outputs.SHOULD_NOT_WORK }}" == "" ]
 
             - name: Run setOutput function using actions/github-script
               uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,7 +16,6 @@ jobs:
               id: github-script-ts
               with:
                   build: npm run format && npm run test && npm run build
-                  path: ./.github
 
             - name: Run prNumber
               id: prNumber
@@ -25,7 +24,6 @@ jobs:
               with:
                   github-token: ${{ secrets.GITHUB_TOKEN }}
                   function: prNumber
-                  path: ./.github
 
             - name: Validate result
               if: github.event_name == 'pull_request'
@@ -42,23 +40,42 @@ jobs:
               with:
                   github-token: ${{ secrets.GITHUB_TOKEN }}
                   function: getLabel
-                  path: ./.github
 
             - if: github.event.act != 'true' && github.event_name == 'pull_request'
               run: |
                   [ "${{ steps.getLabel.outputs.result }}" == "test" ]
 
-            - name: Run setEnv function using actions/github-script
-              uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
+            - name: setOutput and exportVariable suprisingly work when called in a composite run step
+              id: exportVariable
               env:
-                  VARIABLE_NAME: "SET_ENV"
-                  VARIABLE_VALUE: "worked"
+                  OUTPUT_NAME: "SET_IN_COMPOSITE_WORKFLOW"
+                  OUTPUT_VALUE: "cool"
+              uses: ./
+              with:
+                  function: setOutput
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
+
+            - run: |
+                  set -x
+                  [ "${{ steps.exportVariable.outputs.SET_IN_COMPOSITE_WORKFLOW }}" == "cool" ]
+                  [ "${SET_IN_COMPOSITE_WORKFLOW}" == "cool" ]
+                  [ "${{ env.SET_IN_COMPOSITE_WORKFLOW }}" == "cool" ]
+
+            - name: Run setOutput function using actions/github-script
+              uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
+              id: setOutput
+              env:
+                  OUTPUT_NAME: "SET_OUTPUT"
+                  OUTPUT_VALUE: "worked"
               with:
                   github-token: ${{ secrets.GITHUB_TOKEN }}
                   result-encoding: string
                   script: |
-                      const { setEnv } = await import("${{ steps.github-script-ts.outputs.module }}");
-                      const result = await setEnv({core});
+                      const { setOutput } = await import("${{ steps.github-script-ts.outputs.module }}");
+                      const result = await setOutput({core});
 
             - run: |
-                  [ "${SET_ENV}" == "worked" ]
+                  set -x
+                  [ "${SET_OUTPUT}" == "worked" ]
+                  [ "${{ steps.setOutput.outputs.SET_OUTPUT }}" == "worked" ]
+                  [ "${{ env.SET_OUTPUT }}" == "worked" ]

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -56,7 +56,8 @@ jobs:
                   function: setOutput
                   github-token: ${{ secrets.GITHUB_TOKEN }}
 
-            - run: |
+            - if: github.event.act == 'true'
+              run: |
                   set -x
                   [ "${{ steps.exportVariable.outputs.SHOULD_NOT_WORK }}" == "cool" ]
 
@@ -65,13 +66,14 @@ jobs:
               if: github.event.act != 'true'
               env:
                   OUTPUT_NAME: "SHOULD_NOT_WORK"
-                  OUTPUT_VALUE: "cool"
+                  OUTPUT_VALUE: "uh oh"
               uses: ./
               with:
                   function: setOutput
                   github-token: ${{ secrets.GITHUB_TOKEN }}
 
-            - run: |
+            - if: github.event.act != 'true'
+              run: |
                   set -x
                   [ "${{ steps.exportVariableActions.outputs.SHOULD_NOT_WORK }}" == "" ]
 

--- a/README.md
+++ b/README.md
@@ -83,10 +83,10 @@ See [`action.yml`](./action.yml) for all accepted inputs.
 - name: Setup TypeScript scripts
   id: github-script-ts
   uses: urcomputeringpal/github-script-ts@v0
-  with:
-      # path: ./.github
-      # build: npm run build
-      # dist: dist
+  # with:
+  #     path: ./.github
+  #     build: npm run build
+  #     dist: dist
 
   # Run function1. If it returns a value it can be used in subsequent steps
   # by accessing the `result` output of the step like so

--- a/README.md
+++ b/README.md
@@ -113,7 +113,8 @@ See [`action.yml`](./action.yml) for all accepted inputs.
       echo "function1 result: ${{ steps.function1.outputs.result }}"
 
   # You can also use actions/github-script and import your module
-  # from the path specified in the `github-script-ts` step.
+  # from the path specified in the `github-script-ts` step. This allows
+  # setting multiple outputs values using core.setOutput.
 - name: Run custom function using actions/github-script
   id: custom
   uses: actions/github-script@v6

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ A workflow wrapping https://github.com/actions/github-script with Typescript fun
 
 ## Features
 
-- Enables easily running Typescript functions exported from a tiny private module like the one in [`.github/`](./.github/) in Actions workflows. Caches build results automatically.
-- Enables a local testing workflow for advanced Actions logic.
-- Provides a superior experience to editing Javascript embedded in YAML.
+-   Enables easily running Typescript functions exported from a tiny private module like the one in [`.github/`](./.github/) in Actions workflows. Caches build results automatically.
+-   Enables a local testing workflow for advanced Actions logic.
+-   Provides a superior experience to editing Javascript embedded in YAML.
 
 ## Usage
 
@@ -23,7 +23,7 @@ export async function function1(args: GitHubScriptArguments): Promise<String> {
     // const { github, context, core } = args;
     // const { glob, io, exec, fetch } = args;
     // ...
-    return 'string';
+    return "string";
 }
 ```
 
@@ -31,22 +31,6 @@ export async function function1(args: GitHubScriptArguments): Promise<String> {
 
 ```typescript
 export { function1 } from "./function1";
-```
-
-#### `package.json`
-
-```json
-{
-    "name": "ts-scripts",
-    "version": "0.0.1",
-    "private": true,
-    "scripts": {
-        "build": "tsc",
-    },
-    "dependencies": {
-        "@urcomputeringpal/github-script-ts": "0.0.1"
-    }
-}
 ```
 
 #### `tsconfig.json`
@@ -57,10 +41,32 @@ export { function1 } from "./function1";
         "module": "commonjs",
         "declaration": true,
         "target": "es5",
-        "strict": true
+        "strict": true,
+        "outDir": "dist",
+        "esModuleInterop": true
     },
     "include": ["src/*.ts"],
     "exclude": ["node_modules", "**/*.test.ts"]
+}
+```
+
+#### `package.json`
+
+```json
+{
+    "name": "ts-scripts",
+    "version": "0.0.1",
+    "private": true,
+    "scripts": {
+        "build": "tsc"
+        // Build will be run as needed by this Action, don't specify it here
+        // prepare: ""
+    },
+    "files": ["dist/**/*.d.ts", "dist/**/*.js"],
+    "main": "dist/index.js",
+    "dependencies": {
+        "@urcomputeringpal/github-script-ts": "0.0.1"
+    }
 }
 ```
 
@@ -72,9 +78,15 @@ See [`action.yml`](./action.yml) for all accepted inputs.
 - name: Checkout repository
   uses: actions/checkout@v3
 
-  # Perform setup. Caches build results with actions/cache.
+  # Perform setup if called without a 'function'. Compiles your Typescript
+  # module and caches build results with actions/cache.
 - name: Setup TypeScript scripts
+  id: github-script-ts
   uses: urcomputeringpal/github-script-ts@v0
+  with:
+      # path: ./.github
+      # build: npm run build
+      # dist: dist
 
   # Run function1. If it returns a value it can be used in subsequent steps
   # by accessing the `result` output of the step like so
@@ -82,18 +94,41 @@ See [`action.yml`](./action.yml) for all accepted inputs.
 - name: Run function1
   id: function1
   uses: urcomputeringpal/github-script-ts@v0
+  # You can pass environment variables to your script and then
+  # read them from process.env.
+  # https://github.com/actions/github-script/#use-env-as-input
+  env:
+      FOO: bar
   with:
       github-token: ${{ secrets.GITHUB_TOKEN }}
       function: function1
       # args: >
       #   {github, context, core, exec, io, fetch}
       # path: ./.github
-      # build: npm run build
-      # module: src/index.js
+      # dist: dist
       # result-encoding: string
-      
 
 - name: Use function1 result
   run: |
       echo "function1 result: ${{ steps.function1.outputs.result }}"
+
+  # If you want to set multiple outputs or influence the environment,
+  # use actions/github-script directly and import your module from
+  # the path specified in the `github-script-ts` step. The `result`
+  # output will still be set to the return value of your script.
+- name: Run custom function using actions/github-script
+  id: custom
+  uses: actions/github-script@v6
+  # You can pass environment variables to your script and then
+  # read them from process.env.
+  # https://github.com/actions/github-script/#use-env-as-input
+  env:
+      FOO: bar
+  with:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+      result-encoding: string
+      script: |
+          const { custom } = await import("${{ steps.github-script-ts.outputs.module }}");
+          // custom can call core.exportVariable, core.setOutput, etc.
+          return await custom({core,context});
 ```

--- a/README.md
+++ b/README.md
@@ -112,10 +112,8 @@ See [`action.yml`](./action.yml) for all accepted inputs.
   run: |
       echo "function1 result: ${{ steps.function1.outputs.result }}"
 
-  # If you want to set multiple outputs or influence the environment,
-  # use actions/github-script directly and import your module from
-  # the path specified in the `github-script-ts` step. The `result`
-  # output will still be set to the return value of your script.
+  # You can also use actions/github-script and import your module
+  # from the path specified in the `github-script-ts` step.
 - name: Run custom function using actions/github-script
   id: custom
   uses: actions/github-script@v6
@@ -129,6 +127,5 @@ See [`action.yml`](./action.yml) for all accepted inputs.
       result-encoding: string
       script: |
           const { custom } = await import("${{ steps.github-script-ts.outputs.module }}");
-          // custom can call core.exportVariable, core.setOutput, etc.
           return await custom({core,context});
 ```

--- a/action.yml
+++ b/action.yml
@@ -1,24 +1,28 @@
-name: "Run a TypeScript function"
-description: "Runs a TypeScript script using actions/github-script"
+name: Run a TypeScript function
+description: Helper workflow wrapping actions/github-script with TypeScript
 inputs:
     github-token:
         description: The GitHub token used to create an authenticated client
         default: ${{ github.token }}
     path:
-        description: "Path to the functions"
+        description: Path to the functions
         default: ./.github
         required: true
-    module:
-        description: The generated file exporting all of the functions from the module. Defaults to 'src/index.js'.
-        default: src/index.js
+    dist:
+        description: >
+            The primary path to the generated files inside your path directory.
+            Your build script should generate an index.js at this path.
+        default: dist
     build:
-        description: Build command. This command is expected to generate an index.js in the path directory.
+        description: >
+            Build command. This command is expected to generate an index.js in
+            the path directory.
         default: npm run build
     function:
-        description: "Name of the function to call"
+        description: Name of the function to call
         default: ""
     args:
-        description: "Arguments to pass to the function"
+        description: Arguments to pass to the function
         default: "{github, context, core, exec, io, fetch}"
     debug:
         description: Whether to tell the GitHub client to log details of its requests. true or false. Default is to run in debug mode when the GitHub Actions step debug logging is turned on.
@@ -40,11 +44,14 @@ inputs:
         default: 400,401,403,404,422 # from https://github.com/octokit/plugin-retry.js/blob/9a2443746c350b3beedec35cf26e197ea318a261/src/index.ts#L14
 outputs:
     result:
-        description: "Result of the script"
+        description: Result of the script
         value: ${{ steps.script.outputs.result }}
+    module:
+        description: Module to import if calling actions/github-script directly
+        value: ${{ steps.module.outputs.module }}
 
 runs:
-    using: "composite"
+    using: composite
     steps:
         - name: Setup environment
           if: inputs.function == ''
@@ -75,25 +82,28 @@ runs:
               path: |
                   ${{ steps.npm-cache-dir.outputs.dir }}
               key: |
-                  github-script-ts-npm-v2-${{ runner.os }}-${{ hashFiles(format('{0}/{1}', inputs.path, 'package-lock.json')) }}
+                  github-script-ts-npm-v3-${{ runner.os }}-${{ hashFiles(format('{0}/{1}', inputs.path, 'package*.json')) }}
               restore-keys: |
-                  github-script-ts-npm-v2-${{ runner.os }}-
+                  github-script-ts-npm-v3-${{ runner.os }}-
 
         - name: Install dependencies
           if: inputs.function == ''
           shell: bash
+          working-directory: ${{ inputs.path }}
           run: |
-              cd ${{ inputs.path }}
               npm ci
+              mkdir -p tmp/dist
+              echo "${{ inputs.build }}" > tmp/dist/inputs.build
+              echo "${{ inputs.dist }}" > tmp/dist/inputs.dist
 
         - uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
           if: inputs.function == ''
           id: build-cache
           with:
               path: |
-                  ${{ inputs.path }}
+                  ${{ inputs.path }}/${{ inputs.dist }}
               key: |
-                  github-script-ts-build-v2-${{ runner.os }}-${{ hashFiles(format('{0}/{1}', inputs.path, 'package-lock.json')) }}-${{ hashFiles(format('{0}/{1}', inputs.path, '**/*.ts')) }}
+                  github-script-ts-build-v3-${{ runner.os }}-${{ hashFiles(format('{0}/{1}', inputs.path, 'tmp/dist/inputs.*'), format('{0}/{1}', inputs.path, 'package*.json'), format('{0}/{1}', inputs.path, '**/*.ts'), format('{0}/{1}', inputs.path, '**/*.js')) }}
 
         - name: Build
           if: inputs.function == '' && steps.build-cache.outputs.cache-hit != 'true'
@@ -102,10 +112,16 @@ runs:
           run: |
               ${{ inputs.build }}
 
-        - name: "Execute script"
+        - name: Set module output
+          id: module
+          shell: bash
+          run: |
+              echo "module=${{ github.workspace }}/${{ inputs.path }}/${{ inputs.dist }}/index.js" >> "$GITHUB_OUTPUT"
+
+        - name: Execute script
           if: inputs.function != ''
           id: script
-          uses: "actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410" # v6.4.1
+          uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
           env:
               FUNCTION_NAME: ${{ inputs.function }}
           with:
@@ -117,5 +133,5 @@ runs:
               previews: ${{ inputs.previews }}
               retry-exempt-status-codes: ${{ inputs.retry-exempt-status-codes }}
               script: |
-                  const { ${{ env.FUNCTION_NAME }} } = await import('${{ github.workspace }}/${{ inputs.path }}/${{ inputs.module }}')
+                  const { ${{ env.FUNCTION_NAME }} } = await import('${{ steps.module.outputs.module }}')
                   return await ${{ env.FUNCTION_NAME }}(${{ inputs.args }});

--- a/package.json
+++ b/package.json
@@ -1,18 +1,19 @@
 {
     "name": "@urcomputeringpal/github-script-ts",
-    "version": "0.0.5",
+    "version": "0.0.6",
     "description": "actions/github-script for Typescript",
     "repository": "https://github.com/urcomputeringpal/github-script-ts",
     "files": [
-        "src/**/*.d.ts",
-        "src/**/*.js"
+        "dist/**/*.d.ts",
+        "dist/**/*.js"
     ],
-    "main": "src/index.js",
-    "types": "src/types.d.ts",
+    "main": "dist/index.js",
+    "types": "dist/types.d.ts",
     "scripts": {
         "format": "prettier --write .",
         "format:check": "prettier --check .",
         "build": "tsc",
+        "prepare": "npm run build",
         "integration": "./test.sh"
     },
     "dependencies": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,5 +6,6 @@
         "strict": true
     },
     "include": ["src/*.ts"],
-    "exclude": ["node_modules", "**/*.test.ts"]
+    "exclude": ["node_modules", "**/*.test.ts"],
+    "outDir": "dist"
 }


### PR DESCRIPTION
The step now returns a `module` output that be loaded with `import` if previously setup:


```yaml
  - id: github-script-ts
    uses: urcomputeringpal/github-script-ts@v0
    with:
        path: ./.github
  - name: Run custom function using actions/github-script
    id: custom
    uses: actions/github-script@v6
    env:
        NAME: FOO
        VALUE: BAR
    with:
        github-token: ${{ secrets.GITHUB_TOKEN }}
        result-encoding: string
        script: |
            const { custom } = await import("${{ steps.github-script-ts.outputs.module }}");
            // custom can call core.setOutput and set multiple outputs in addition to
            // result, containing the return value
            return await custom({core});
```

Also encourages an explicit `dist` dir for better caching.